### PR TITLE
Add sharing buttons in offer show

### DIFF
--- a/assets/brunch-config.js
+++ b/assets/brunch-config.js
@@ -49,7 +49,10 @@ exports.config = {
       ignore: [/vendor/]
     },
     sass: {
-      mode: "native" // This is the important part!
+      mode: "native", // This is the important part!
+      options: {
+        includePaths: ['node_modules']
+      }
     }
   },
 

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -1,6 +1,8 @@
 /* This file is for your main application css. */
 @import "config";
 
+@import "rrssb/scss/rrssb";
+
 @import "mixins/commons";
 @import "mixins/btn";
 @import "mixins/responsive";

--- a/assets/css/components/_offer.scss
+++ b/assets/css/components/_offer.scss
@@ -104,6 +104,7 @@
 
 .rrssb-buttons-wrapper {
   padding: 0;
+  margin-bottom: 1rem;
   .rrssb-buttons-title {
     font-weight: bold;
     margin: 0.6rem auto 0.4rem;
@@ -114,7 +115,7 @@
 }
 
 .offer-link {
-  margin: 3rem 0;
+  margin: 1rem 0;
 }
 
 .no-offer {
@@ -212,7 +213,7 @@
   }
 
   .offer-link {
-    margin: 2rem 0;
+    margin: 1rem 0;
   }
 
   .offer-new {

--- a/assets/css/components/_offer.scss
+++ b/assets/css/components/_offer.scss
@@ -102,6 +102,17 @@
   }
 }
 
+.rrssb-buttons-wrapper {
+  padding: 0;
+  .rrssb-buttons-title {
+    font-weight: bold;
+    margin: 0.6rem auto 0.4rem;
+  }
+  .rrssb-buttons {
+    margin-left: -2px;
+  }
+}
+
 .offer-link {
   margin: 3rem 0;
 }
@@ -184,6 +195,9 @@
       }
     }
   }
+  .rrssb-buttons-wrapper {
+    padding: .5rem .5rem 0 .5rem;
+  }
 }
 
 @include screen-md {
@@ -207,5 +221,8 @@
         margin-bottom: 0;
       }
     }
+  }
+  .rrssb-buttons-wrapper {
+    padding: 0;
   }
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -8,6 +8,7 @@ import "phoenix_html"
 // import socket from "./socket"
 
 import "jquery";
+import "rrssb/js/rrssb";
 
 jQuery(function ($) {
   $("a[data-toggle]").click(function (evt) {
@@ -36,5 +37,11 @@ jQuery(function ($) {
         scrollTop: $preview_div.offset().top
       }, 'slow');
     });
+  });
+
+  $(".rrssb-buttons").rrssb({
+    title: document.title,
+    url: document.location.href,
+    description: $('meta[name=description]').attr("content")
   });
 });

--- a/assets/package.json
+++ b/assets/package.json
@@ -9,7 +9,8 @@
     "jquery": "^3.2.1",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",
-    "sass-brunch": "^2.10.4"
+    "sass-brunch": "^2.10.4",
+    "rrssb": "^1.14.0"
   },
   "devDependencies": {
     "babel-brunch": "6.1.1",

--- a/lib/elixir_jobs_web/templates/offer/show.html.eex
+++ b/lib/elixir_jobs_web/templates/offer/show.html.eex
@@ -1,4 +1,5 @@
 <%= render("_offer.html", conn: @conn, offer: @offer, title_link: false) %>
+<%= render(ElixirJobsWeb.SharedView, "_share.html") %>
 <div class="offer-link">
   <%= link(gettext("Go to the offer!"), to: @offer.url, class: "btn-info", target: "_blank") %>
   <%= if user_logged_in?(@conn) do %>

--- a/lib/elixir_jobs_web/templates/offer/show.html.eex
+++ b/lib/elixir_jobs_web/templates/offer/show.html.eex
@@ -1,5 +1,4 @@
 <%= render("_offer.html", conn: @conn, offer: @offer, title_link: false) %>
-<%= render(ElixirJobsWeb.SharedView, "_share.html") %>
 <div class="offer-link">
   <%= link(gettext("Go to the offer!"), to: @offer.url, class: "btn-info", target: "_blank") %>
   <%= if user_logged_in?(@conn) do %>
@@ -22,3 +21,4 @@
       data: [confirm: gettext("Do you really want to delete this offer?")]) %>
   <% end %>
 </div>
+<%= render(ElixirJobsWeb.SharedView, "_share.html") %>

--- a/lib/elixir_jobs_web/templates/shared/_share.html.eex
+++ b/lib/elixir_jobs_web/templates/shared/_share.html.eex
@@ -1,0 +1,61 @@
+<div class="rrssb-buttons-wrapper">
+  <p class="rrssb-buttons-title"><%= gettext("Share this offer:") %></p>
+  <ul class="rrssb-buttons clearfix">
+    <li class="rrssb-twitter small" data-initwidth="14.285714285714286" style="width: 42px;" data-size="53">
+      <a href="#" class="popup">
+        <span class="rrssb-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28">
+            <path
+            d="M24.253 8.756C24.69 17.08 18.297 24.182 9.97 24.62c-3.122.162-6.22-.646-8.86-2.32 2.702.18 5.375-.648 7.507-2.32-2.072-.248-3.818-1.662-4.49-3.64.802.13 1.62.077 2.4-.154-2.482-.466-4.312-2.586-4.412-5.11.688.276 1.426.408 2.168.387-2.135-1.65-2.73-4.62-1.394-6.965C5.574 7.816 9.54 9.84 13.802 10.07c-.842-2.738.694-5.64 3.434-6.48 2.018-.624 4.212.043 5.546 1.682 1.186-.213 2.318-.662 3.33-1.317-.386 1.256-1.248 2.312-2.4 2.942 1.048-.106 2.07-.394 3.02-.85-.458 1.182-1.343 2.15-2.48 2.71z"></path>
+          </svg>
+        </span>
+        <span class="rrssb-text">twitter</span>
+      </a>
+    </li>
+    <li class="rrssb-linkedin" data-initwidth="14.285714285714286" style="width: calc(33.3333% - 56px);" data-size="57">
+      <a href="#" class="popup">
+        <span class="rrssb-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28">
+            <path
+              d="M25.424 15.887v8.447h-4.896v-7.882c0-1.98-.71-3.33-2.48-3.33-1.354 0-2.158.91-2.514 1.802-.13.315-.162.753-.162 1.194v8.216h-4.9s.067-13.35 0-14.73h4.9v2.087c-.01.017-.023.033-.033.05h.032v-.05c.65-1.002 1.812-2.435 4.414-2.435 3.222 0 5.638 2.106 5.638 6.632zM5.348 2.5c-1.676 0-2.772 1.093-2.772 2.54 0 1.42 1.066 2.538 2.717 2.546h.032c1.71 0 2.77-1.132 2.77-2.546C8.056 3.593 7.02 2.5 5.344 2.5h.005zm-2.48 21.834h4.896V9.604H2.867v14.73z"></path>
+          </svg>
+        </span>
+        <span class="rrssb-text">linkedin</span>
+      </a>
+    </li>
+    <li class="rrssb-facebook" data-initwidth="14.285714285714286" style="width: calc(33.3333% - 56px);" data-size="68">
+      <a href="#" class="popup">
+        <span class="rrssb-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid" width="29" height="29" viewBox="0 0 29 29">
+            <path
+            d="M26.4 0H2.6C1.714 0 0 1.715 0 2.6v23.8c0 .884 1.715 2.6 2.6 2.6h12.393V17.988h-3.996v-3.98h3.997v-3.062c0-3.746 2.835-5.97 6.177-5.97 1.6 0 2.444.173 2.845.226v3.792H21.18c-1.817 0-2.156.9-2.156 2.168v2.847h5.045l-.66 3.978h-4.386V29H26.4c.884 0 2.6-1.716 2.6-2.6V2.6c0-.885-1.716-2.6-2.6-2.6z"
+            fill-rule="evenodd"
+            class="cls-2"></path>
+          </svg>
+        </span>
+        <span class="rrssb-text">facebook</span>
+      </a>
+    </li>
+    <li class="rrssb-googleplus small" data-initwidth="14.285714285714286" style="width: 42px;" data-size="60">
+      <a href="#" class="popup">
+        <span class="rrssb-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path
+              d="M21 8.29h-1.95v2.6h-2.6v1.82h2.6v2.6H21v-2.6h2.6v-1.885H21V8.29zM7.614 10.306v2.925h3.9c-.26 1.69-1.755 2.925-3.9 2.925-2.34 0-4.29-2.016-4.29-4.354s1.885-4.353 4.29-4.353c1.104 0 2.014.326 2.794 1.105l2.08-2.08c-1.3-1.17-2.924-1.883-4.874-1.883C3.65 4.586.4 7.835.4 11.8s3.25 7.212 7.214 7.212c4.224 0 6.953-2.988 6.953-7.082 0-.52-.065-1.104-.13-1.624H7.614z"></path>
+          </svg>
+        </span>
+        <span class="rrssb-text">google+</span>
+      </a>
+    </li>
+    <li class="rrssb-email" data-initwidth="14.285714285714286" style="width: calc(33.3333% - 56px);" data-size="37">
+      <a href="#">
+        <span class="rrssb-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <path d="M21.386 2.614H2.614A2.345 2.345 0 0 0 .279 4.961l-.01 14.078a2.353 2.353 0 0 0 2.346 2.347h18.771a2.354 2.354 0 0 0 2.347-2.347V4.961a2.356 2.356 0 0 0-2.347-2.347zm0 4.694L12 13.174 2.614 7.308V4.961L12 10.827l9.386-5.866v2.347z"></path>
+          </svg>
+        </span>
+        <span class="rrssb-text">email</span>
+      </a>
+    </li>
+  </ul>
+</div>


### PR DESCRIPTION
Connects to #1.

This pull request adds [rrssb](https://github.com/kni-labs/rrssb) in order to be able to add share buttons to the offer show template.

The placement of the social buttons looks like this:

<img width="1436" alt="offer" src="https://user-images.githubusercontent.com/4928335/30787658-40d84cea-a18e-11e7-93fe-a3d7b24b0892.png">
