### PR TITLE
Add extra field to job listing 

### DIFF
--- a/assets/css/components/_offer.scss
+++ b/assets/css/components/_offer.scss
@@ -100,6 +100,10 @@
       text-decoration: underline;
     }
   }
+  .summary {
+      font-size: 0.9rem;
+      min-height: 0px;
+  }
 }
 
 .rrssb-buttons-wrapper {

--- a/lib/elixir_jobs/offers/offer.ex
+++ b/lib/elixir_jobs/offers/offer.ex
@@ -18,6 +18,7 @@ defmodule ElixirJobs.Offers.Offer do
     field :location, :string
     field :url, :string
     field :slug, :string
+    field :summary, :string
 
     field :job_place, JobPlace
     field :job_type, JobType
@@ -28,7 +29,7 @@ defmodule ElixirJobs.Offers.Offer do
   end
 
   @required_attrs [:title, :company, :description, :location, :url, :job_place, :job_type]
-  @optional_attrs [:published_at, :slug]
+  @optional_attrs [:published_at, :slug, :summary]
   @attributes @required_attrs ++ @optional_attrs
 
   @doc false
@@ -38,7 +39,8 @@ defmodule ElixirJobs.Offers.Offer do
     |> validate_required(@required_attrs)
     |> validate_length(:title, min: 5, max: 50)
     |> validate_length(:company, min: 2, max: 30)
-    |> validate_length(:description, min: 10, max: 500)
+    |> validate_length(:description, min: 10, max: 1000)
+    |> validate_length(:summary, max: 200)
     |> validate_length(:location, min: 3, max: 50)
     |> validate_length(:url, min: 1, max: 255)
     |> validate_format(:url, ~r/^\b((https?:\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/)))$/)

--- a/lib/elixir_jobs/offers/offer.ex
+++ b/lib/elixir_jobs/offers/offer.ex
@@ -28,8 +28,8 @@ defmodule ElixirJobs.Offers.Offer do
     timestamps()
   end
 
-  @required_attrs [:title, :company, :description, :location, :url, :job_place, :job_type]
-  @optional_attrs [:published_at, :slug, :summary]
+  @required_attrs [:title, :company, :description, :location, :url, :job_place, :job_type, :summary]
+  @optional_attrs [:published_at, :slug]
   @attributes @required_attrs ++ @optional_attrs
 
   @doc false
@@ -40,7 +40,7 @@ defmodule ElixirJobs.Offers.Offer do
     |> validate_length(:title, min: 5, max: 50)
     |> validate_length(:company, min: 2, max: 30)
     |> validate_length(:description, min: 10, max: 1000)
-    |> validate_length(:summary, max: 200)
+    |> validate_length(:summary, min: 10, max: 200)
     |> validate_length(:location, min: 3, max: 50)
     |> validate_length(:url, min: 1, max: 255)
     |> validate_format(:url, ~r/^\b((https?:\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/)))$/)

--- a/lib/elixir_jobs_web/controllers/offer_controller.ex
+++ b/lib/elixir_jobs_web/controllers/offer_controller.ex
@@ -95,6 +95,7 @@ defmodule ElixirJobsWeb.OfferController do
       title: Map.get(offer_params, "title") || gettext("Title of your offer"),
       company: Map.get(offer_params, "company") || gettext("Company"),
       description: Map.get(offer_params, "description") || gettext("Description of your offer"),
+      summary: Map.get(offer_params, "summary") || gettext("summary of your offer"),
       location: Map.get(offer_params, "location") || gettext("Location"),
       url: Map.get(offer_params, "url") || "https://example.com",
       slug: "",

--- a/lib/elixir_jobs_web/templates/email/offer_created.html.eex
+++ b/lib/elixir_jobs_web/templates/email/offer_created.html.eex
@@ -5,6 +5,7 @@
   <h4><%= gettext("Title") %>: <%= @offer.title %></h4>
   <p><%= gettext("Company") %>: <%= @offer.company %></p>
   <hr />
+  <p><%= gettext("Summary") %>: <%= @offer.summary %></p>
   <p><%= gettext("Description") %>: <%= @offer.description %></p>
   <p><%= gettext("Location") %>: <%= @offer.location %></p>
   <p><%= gettext("URL") %>: <a href="<%= @offer.url %>" target="_blank"><%= @offer.url %></a></p>

--- a/lib/elixir_jobs_web/templates/email/offer_created.text.eex
+++ b/lib/elixir_jobs_web/templates/email/offer_created.text.eex
@@ -3,6 +3,7 @@
 <%= gettext("Title") %>: <%= @offer.title %>
 <%= gettext("Company") %>: <%= @offer.company %>
 ----
+<%= gettext("Summary") %>: <%= @offer.summary %>
 <%= gettext("Description") %>: <%= @offer.description %>
 <%= gettext("Location") %>: <%= @offer.location %>
 <%= gettext("URL") %>: <%= @offer.url %>

--- a/lib/elixir_jobs_web/templates/offer/_form.html.eex
+++ b/lib/elixir_jobs_web/templates/offer/_form.html.eex
@@ -30,7 +30,20 @@
 
     <fieldset>
       <div class="field-container">
+        <%= textarea(f, :summary,
+          rows: 3,
+          maxlength: 200,
+          id: "offer_summary",
+          class: class_with_error(f, :summary, "summary"),
+          placeholder: gettext("Offer summary (max 200 characters)")) %>
+        <%= error_tag(f, :summary) %>
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <div class="field-container">
         <%= textarea(f, :description,
+          maxlength: 1000,
           id: "offer_description",
           class: class_with_error(f, :description, "description"),
           placeholder: gettext("Text should describe the offer itself. Remember, this text can potentially engage your candidates!")) %>
@@ -62,7 +75,7 @@
       <div>
         <small>
           Your offer might be edited (typos, wording, etc.)<br>
-          You can use Markdown (<a href="#" data-toggle="#formatting-help">formatting help</a>).
+          You can use Markdown for description (<a href="#" data-toggle="#formatting-help">formatting help</a>).
         </small>
 
         <span>

--- a/lib/elixir_jobs_web/templates/offer/_form.html.eex
+++ b/lib/elixir_jobs_web/templates/offer/_form.html.eex
@@ -35,7 +35,7 @@
           maxlength: 200,
           id: "offer_summary",
           class: class_with_error(f, :summary, "summary"),
-          placeholder: gettext("Offer summary (max 200 characters)")) %>
+          placeholder: gettext("Summary (will be shown in listings, max 200 characters)")) %>
         <%= error_tag(f, :summary) %>
       </div>
     </fieldset>
@@ -46,7 +46,7 @@
           maxlength: 1000,
           id: "offer_description",
           class: class_with_error(f, :description, "description"),
-          placeholder: gettext("Text should describe the offer itself. Remember, this text can potentially engage your candidates!")) %>
+          placeholder: gettext("Text should describe the offer itself and engage your candidates (will be shown in offer details page)")) %>
         <%= error_tag(f, :description) %>
       </div>
     </fieldset>

--- a/lib/elixir_jobs_web/templates/offer/_offer.html.eex
+++ b/lib/elixir_jobs_web/templates/offer/_offer.html.eex
@@ -33,7 +33,15 @@
       </span>
     </div>
   </div>
-  <div class="description">
-    <%= sanitized_markdown(@offer.description) %>
-  </div>
+  <%= if @details do %>
+    <div class="description">
+      <p> <%= @offer.summary %> </p>
+      <%= sanitized_markdown(@offer.description) %>
+    </div>
+  <% else %>
+    <div class="summary">
+      <%= @offer.summary %>
+    </div>
+  <% end %>
+
 </div>

--- a/lib/elixir_jobs_web/templates/offer/_offer.html.eex
+++ b/lib/elixir_jobs_web/templates/offer/_offer.html.eex
@@ -35,7 +35,6 @@
   </div>
   <%= if @details do %>
     <div class="description">
-      <p> <%= @offer.summary %> </p>
       <%= sanitized_markdown(@offer.description) %>
     </div>
   <% else %>

--- a/lib/elixir_jobs_web/templates/offer/index.html.eex
+++ b/lib/elixir_jobs_web/templates/offer/index.html.eex
@@ -1,7 +1,7 @@
 <%= render("_filters.html", conn: @conn, aspect: "small", page_number: @page_number, total_pages: @total_pages) %>
 
 <%= for offer <- @offers do %>
-  <%= render("_offer.html", conn: @conn, offer: offer, title_link: true) %>
+  <%= render("_offer.html", conn: @conn, offer: offer, title_link: true, details: false) %>
 <% end %>
 
 <%= if length(@offers) == 0 do %>

--- a/lib/elixir_jobs_web/templates/offer/preview.html.eex
+++ b/lib/elixir_jobs_web/templates/offer/preview.html.eex
@@ -1,4 +1,4 @@
-<%= render("_offer.html", conn: @conn, offer: @offer, title_link: false) %>
+<%= render("_offer.html", conn: @conn, offer: @offer, title_link: false, details: true) %>
 <div class="offer-link">
   <%= link(gettext("Go to the offer!"), to: @offer.url, class: "btn btn-info", target: "_blank") %>
 </div>

--- a/lib/elixir_jobs_web/templates/offer/rss.xml.eex
+++ b/lib/elixir_jobs_web/templates/offer/rss.xml.eex
@@ -16,6 +16,7 @@
               <%= gettext "Job type:" %> <%= human_get_type(offer.job_type, gettext("Unknown")) %>
             </font>
           </font>
+          <%= offer.summary %>
           <%= xml_sanitized_markdown(offer.description) %>
         ]]></description>
         <pubDate><%= xml_readable_date(offer.inserted_at) %></pubDate>

--- a/lib/elixir_jobs_web/templates/offer/rss.xml.eex
+++ b/lib/elixir_jobs_web/templates/offer/rss.xml.eex
@@ -19,7 +19,6 @@
               <%= gettext "Job location:" %> <%= xml_strip_tags(offer.location) %>
             </font>
           </font>
-          <%= offer.summary %>
           <%= xml_sanitized_markdown(offer.description) %>
         ]]></description>
         <pubDate><%= xml_readable_date(offer.inserted_at) %></pubDate>

--- a/lib/elixir_jobs_web/templates/offer/search.html.eex
+++ b/lib/elixir_jobs_web/templates/offer/search.html.eex
@@ -1,7 +1,7 @@
 <%= render("_filters.html", conn: @conn, aspect: "full", page_number: @page_number, total_pages: @total_pages) %>
 
 <%= for offer <- @offers do %>
-  <%= render("_offer.html", conn: @conn, offer: offer, title_link: true) %>
+  <%= render("_offer.html", conn: @conn, offer: offer, title_link: true, details: false) %>
 <% end %>
 
 <%= if length(@offers) == 0 do %>

--- a/lib/elixir_jobs_web/templates/offer/show.html.eex
+++ b/lib/elixir_jobs_web/templates/offer/show.html.eex
@@ -1,4 +1,4 @@
-<%= render("_offer.html", conn: @conn, offer: @offer, title_link: false) %>
+<%= render("_offer.html", conn: @conn, offer: @offer, title_link: false, details: true) %>
 <div class="offer-link">
   <%= link(gettext("Go to the offer!"), to: @offer.url, class: "btn-info", target: "_blank") %>
   <%= if user_logged_in?(@conn) do %>

--- a/lib/elixir_jobs_web/views/seo_helper.ex
+++ b/lib/elixir_jobs_web/views/seo_helper.ex
@@ -51,8 +51,7 @@ defmodule ElixirJobsWeb.SeoHelper do
 
   defp get_page_description(OfferController, :new, _), do: gettext("Post your job offer to reach more Elixir developers and find the right hire for your company!")
   defp get_page_description(OfferController, :show, %{:offer => %Offer{} = offer}) do
-    offer.description
-    |> Earmark.as_html!()
+    offer.summary
     |> HtmlSanitizeEx.strip_tags()
     |> String.slice(0, 100)
   end

--- a/priv/repo/migrations/20171001195406_add_summary_to_offers.exs
+++ b/priv/repo/migrations/20171001195406_add_summary_to_offers.exs
@@ -3,7 +3,7 @@ defmodule ElixirJobs.Repo.Migrations.AddSummaryToOffers do
 
   def change do
     alter table(:offers) do
-      add :summary, :string
+      add :summary, :string, size: 200
     end
 
   end

--- a/priv/repo/migrations/20171001195406_add_summary_to_offers.exs
+++ b/priv/repo/migrations/20171001195406_add_summary_to_offers.exs
@@ -1,0 +1,10 @@
+defmodule ElixirJobs.Repo.Migrations.AddSummaryToOffers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:offers) do
+      add :summary, :string
+    end
+
+  end
+end

--- a/priv/repo/migrations/20171002122508_change_description_character_limit_offers_table.exs
+++ b/priv/repo/migrations/20171002122508_change_description_character_limit_offers_table.exs
@@ -1,0 +1,10 @@
+defmodule ElixirJobs.Repo.Migrations.ChangeDescriptionCharacterLimitOffersTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:offers) do
+      modify :description, :string, size: 1000
+    end
+
+  end
+end

--- a/test/elixir_jobs/offers/offers_test.exs
+++ b/test/elixir_jobs/offers/offers_test.exs
@@ -13,6 +13,7 @@ defmodule ElixirJobs.OffersTest do
     @valid_attrs %{
       title: "some title",
       company: "some company",
+      summary: "some summary",
       description: "some description",
       location: "some location",
       url: "https://www.google.com",
@@ -22,6 +23,7 @@ defmodule ElixirJobs.OffersTest do
     @update_attrs %{
       title: "some updated title",
       company: "some updated company",
+      summary: "some updated summary",
       description: "some updated description",
       location: "some updated location",
       url: "https://www.google.es",
@@ -61,6 +63,7 @@ defmodule ElixirJobs.OffersTest do
       assert {:ok, %Offer{} = offer} = Offers.create_offer(@valid_attrs)
       assert offer.title == "some title"
       assert offer.company == "some company"
+      assert offer.summary == "some summary"
       assert offer.description == "some description"
       assert offer.location == "some location"
       assert offer.url == "https://www.google.com"
@@ -78,6 +81,7 @@ defmodule ElixirJobs.OffersTest do
       assert %Offer{} = offer
       assert offer.title == "some updated title"
       assert offer.company == "some updated company"
+      assert offer.summary == "some updated summary"
       assert offer.description == "some updated description"
       assert offer.location == "some updated location"
       assert offer.url == "https://www.google.es"

--- a/test/elixir_jobs_web/controllers/emails/emails_test.exs
+++ b/test/elixir_jobs_web/controllers/emails/emails_test.exs
@@ -12,6 +12,7 @@ defmodule ElixirJobsWeb.EmailsTest do
     @valid_offer %{
       title: "some title",
       company: "some company",
+      summary: "some summary",
       description: "some description",
       location: "some location",
       url: "https://www.google.com",


### PR DESCRIPTION
This fixes #8 

- [x] Added a `summary` field to job offer posting/listing
- [x] Offer `summary` is optional
- [x] Offer `summary` is text only 
- [x] Show only job offer summary on index page
- [x] Show offer summary and description on details page
- [x] Offer summary has character limit of `200`
- [x] Offer description character limit increased to `1000`

The `200` character limit for the offer `summary` was arrived at by looking at the number of characters used for the first paragraph of the current job postings. 